### PR TITLE
refactor: rename variable for clarity in access token validation service

### DIFF
--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -481,7 +481,9 @@ const checkAccessTokenExpiredService = async (accessToken) => {
       accessToken,
       process.env.ACCESS_TOKEN_SECRET
     );
-    const email = decodedToken._id;
+    const userId = decodedToken._id;
+
+    console.log(userId);
 
     const connection = new DatabaseTransaction();
     const user = await connection.userRepository.findUserById(userId);


### PR DESCRIPTION
- Changed variable name from 'email' to 'userId' for better readability.
- Added console log for userId to assist in debugging.